### PR TITLE
fix error when using EmailMessage headers argument

### DIFF
--- a/db_email_backend/backend.py
+++ b/db_email_backend/backend.py
@@ -19,7 +19,7 @@ class DBEmailBackend(BaseEmailBackend):
                     cc='; '.join(msg.cc),
                     bcc='; '.join(msg.bcc),
                     headers='\n'.join('{}: {}'.format(k, v)
-                                      for k, v in msg.extra_headers),
+                                      for k, v in msg.extra_headers.items()),
                 )
                 alternatives = getattr(msg, 'alternatives', [])
                 for content, mimetype in alternatives:


### PR DESCRIPTION
With this fix it raises `ValueError: too many values to unpack (expected 2)` when adding some custom headers.