### PR TITLE
Django 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - TOXENV=django18
     - TOXENV=django19
     - TOXENV=django110
+    - TOXENV=django20
 install:
     - pip install tox
 script:

--- a/db_email_backend/models.py
+++ b/db_email_backend/models.py
@@ -23,7 +23,7 @@ class Email(models.Model):
 
 @python_2_unicode_compatible
 class EmailAlternative(models.Model):
-    email = models.ForeignKey(Email, related_name='alternatives')
+    email = models.ForeignKey(Email, on_delete=models.CASCADE, related_name='alternatives')
     content = models.TextField(blank=True)
     mimetype = models.CharField(max_length=254, blank=True)
 
@@ -33,7 +33,7 @@ class EmailAlternative(models.Model):
 
 @python_2_unicode_compatible
 class EmailAttachment(models.Model):
-    email = models.ForeignKey(Email, related_name='attachments')
+    email = models.ForeignKey(Email, on_delete=models.CASCADE, related_name='attachments')
     filename = models.CharField(max_length=1000, blank=True)
     mimetype = models.CharField(max_length=254, blank=True)
     file = models.FileField(upload_to='db_email_backend')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django14, django15, django16, django17, django18, django19, django110
+envlist = django14, django15, django16, django17, django18, django19, django110, django20
 
 [legacy_base]
 deps =
@@ -60,6 +60,12 @@ deps =
     django>=1.10, <1.11
     {[base]deps}
 
+[testenv:django20]
+basepython=python3.4
+deps =
+    django>=2.0, <2.1
+    {[base]deps}
+
 [testenv:coverage]
 basepython=python3.4
 commands =
@@ -67,4 +73,4 @@ commands =
     coveralls
 deps =
     coveralls
-    {[testenv:django110]deps}
+    {[testenv:django20]deps}


### PR DESCRIPTION
A simple change: adding the now-required `on_delete` to the ForeignKeys.

One test fails though:

```
FAIL: test_send_attachments (backend_tests.DBEmailBackendTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jon/.virtualenvs/bravo20/src/django-db-email-backend/db_email_backend/tests/backend_tests.py", line 56, in test_send_attachments
    self.assertEqual(attachment.mimetype, 'application/octet-stream')
AssertionError: 'text/markdown' != 'application/octet-stream'
- text/markdown
+ application/octet-stream
```

I'm not sure if the test is wrong (it's a markdown file, seems like 'text/markdown' would be correct...) or if it is supposed to be 'application/octet-stream' for some reason instead.