### PR TITLE
Bring up to spec for 2.1 and 2.2

### DIFF
--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -1,4 +1,5 @@
 import os
+import django
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEBUG = True
 
@@ -25,13 +26,38 @@ INSTALLED_APPS = (
     'db_email_backend',
 )
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-)
+if django.VERSION >= (1, 10):
+    MIDDLEWARE = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware'
+    )
+else:
+    MIDDLEWARE_CLASSES = (
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware'
+    )
+
+if django.VERSION >= (1, 8):
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages'
+                ]
+            },
+        },
+    ]
 
 DEFAULT_FILE_STORAGE = 'test_app.storage.TestStorage'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,36}-django{18,19,110,111}
-    py{36}-django{20}
+    py{36}-django{20,21,22}
 
 [travis:env]
 DJANGO =
@@ -10,6 +10,8 @@ DJANGO =
     1.10: django110
     1.11: django111
     2.0: django20
+    2.1: django21
+    2.2: django22
 
 [testenv]
 commands = django-admin.py test
@@ -22,6 +24,8 @@ deps =
     django110: django>=1.10, <1.11
     django111: django>=1.11, <2.0
     django20: django>=2.0, <2.1
+    django21: django>=2.1, <2.2
+    django22: django>=2.2, <2.3
 
 [testenv:coverage]
 basepython=python3.6


### PR DESCRIPTION
1. Add 2.1 and 2.2 to tox for tests
2. Django 2.2 run settings checks before tests. Added settings to test app for those checks, based on the version those features were released